### PR TITLE
fine tune numbers in tables 1 and 2, consistency for bandwidth-delay

### DIFF
--- a/algorithm.rst
+++ b/algorithm.rst
@@ -545,9 +545,9 @@ enough capacity to support 16 packets from this source. The likely
 result is that 16 of the 32 packets sent under the new congestion
 window will be dropped by the network; actually, this is the
 worst-case outcome, since some of the packets will be buffered in some
-router. This problem will become increasingly severe as the delay ×
-bandwidth product of networks increases. For example, a delay ×
-bandwidth product of 1.8 MB means that each connection has the
+router. This problem will become increasingly severe as the 
+bandwidth-delay product of networks increases. For example, a 
+bandwidth-delay product of 1.8 MB means that each connection has the
 potential to lose up to 1.8 MB of data at the beginning of each
 connection. Of course, this assumes that both the source and the
 destination implement the "big windows” extension.
@@ -740,7 +740,7 @@ SACK was shown to improve the performance of TCP Reno particularly in
 the case where multiple packets were dropped in a single RTT, as would
 be expected (since cumulative ACK and SACK are the same thing when only
 one packet is dropped). This scenario became more likely over time as
-bandwidth x delay products increased, leaving more packets in the pipe
+bandwidth-delay products increased, leaving more packets in the pipe
 for a given RTT. Hence SACK, which became a proposed IETF standard in
 1996, was a timely addition to TCP. 
 

--- a/aqm.rst
+++ b/aqm.rst
@@ -376,7 +376,7 @@ in itself a problem. There should be enough buffer capacity to
 absorb such bursts. Problems arise when there is not enough buffer
 capacity to absorb bursts, leading to excessive loss. This came to be
 understood in the 1990s as a requirement that buffers be able to hold
-at least one delay x bandwidth product of packets—a requirement that
+at least one bandwidth-delay product of packets—a requirement that
 was probably too large and subsequently questioned by further
 research. But the fact is that buffers are necessary, and it is
 expected that they will be used to absorb bursts. The CoDel authors

--- a/avoidance.rst
+++ b/avoidance.rst
@@ -196,7 +196,7 @@ in Chapter 7.
 ~~~~~~~~~~~~~~
 
 The first Vegas-inspired mechanism was FAST TCP, which modified Vegas
-to be more efficient on high-speed networks with large delay-bandwidth
+to be more efficient on high-speed networks with large bandwidth-delay
 products. The idea was to increase the congestion window more
 aggressively during the phase when the algorithm is trying to find the
 available "in transit" bandwidth (before packets are buffered in the
@@ -204,7 +204,7 @@ network), and then more conservatively as the algorithm starts to
 compete with other flows for buffers at the bottleneck router. FAST
 also recommended adjusting the value of |alpha| to roughly 30 packets.
 
-Beyond managing congestion in networks with large delay-bandwidth
+Beyond managing congestion in networks with large bandwidth-delay
 products, where keeping the pipe full is a substantial challenge,
 there are two other items of note about FAST. First, whereas both TCP
 Reno and TCP Vegas were the result of a little intuition and a lot of

--- a/design.rst
+++ b/design.rst
@@ -742,8 +742,8 @@ an increased likelihood that queuing delays become an issue. For
 example, :numref:`Figure %s <fig-graph_16b>` shows the 99% latencies
 for four different algorithms when the network topology includes a
 10-Mbps bottleneck link and a 40ms RTT. One important observation
-about this result is that the second algorithm (red) performs poorly
-when there is less than one delay-bandwidth product of buffering
+about this result is that the second algorithm (RED) performs poorly
+when there is less than one bandwidth-delay product of buffering
 available at the bottleneck router, calling attention to another
 variable that can influence your results.
 

--- a/tcp_ip.rst
+++ b/tcp_ip.rst
@@ -702,17 +702,17 @@ bandwidths.
    +--------------------------+-----------------------+
    | Bandwidth                | Time until Wraparound |
    +==========================+=======================+
-   | T1 (1.5 Mbps)            | 6.4 hours             |
+   | T1 (1.5 Mbps)            | 6.2 hours             |
    +--------------------------+-----------------------+
-   | T3 (45 Mbps)             | 13 minutes            |
+   | T3 (44.7 Mbps)           | 12.8 minutes          |
    +--------------------------+-----------------------+
-   | OC-3 (155 Mbps)          | 4 minutes             |
+   | OC-3 (148.6 Mbps)        | 3.9 minutes           |
    +--------------------------+-----------------------+
-   | OC-48 (2.5 Gbps)         | 14 seconds            |
+   | OC-48 (2.4 Gbps)         | 14.3 seconds          |
    +--------------------------+-----------------------+
-   | OC-192 (10 Gbps)         | 3 seconds             |
+   | OC-192 (9.5 Gbps)        | 3.6 seconds           |
    +--------------------------+-----------------------+
-   | 10GigE (10 Gbps)         | 3 seconds             |
+   | 10GigE (10 Gbps)         | 3.4 seconds           |
    +--------------------------+-----------------------+
 
 The 32-bit sequence number space is adequate at modest bandwidths, but
@@ -734,13 +734,15 @@ receiver is free to not open the window as large as the
 which the receiver has enough buffer space to handle as much data as the
 largest possible ``AdvertisedWindow`` allows.
 
-In this case, it is not just the network bandwidth but the delay x
-bandwidth product that dictates how big the ``AdvertisedWindow`` field
+In this case, it is not just the network bandwidth but the 
+bandwidth-delay product that dictates how big the ``AdvertisedWindow`` field
 needs to be—the window needs to be opened far enough to allow a full
-delay × bandwidth product’s worth of data to be transmitted. Assuming an
+bandwidth-delay product’s worth of data to be transmitted. Assuming an
 RTT of 100 ms (a typical number for a cross-country connection in the
-United States), :numref:`Table %s <tab-adv-win>` gives the delay × bandwidth
-product for several network technologies.
+United States), :numref:`Table %s <tab-adv-win>` gives the bandwidth-delay
+product for several network technologies. Note that for the OC-n links
+we've used the available link bandwidth after removing SONET
+overhead. 
 
 .. _tab-adv-win:
 .. table::  Required Window Size for 100-ms RTT
@@ -748,19 +750,19 @@ product for several network technologies.
    :widths: auto   
 
    +--------------------------+---------------------------+
-   | Bandwidth                | Delay × Bandwidth Product |
+   | Bandwidth                | Bandwidth × Delay Product |
    +==========================+===========================+
-   | T1 (1.5 Mbps)            | 18 KB                     |
+   | T1 (1.5 Mbps)            | 18.8 KB                   |
    +--------------------------+---------------------------+
-   | T3 (45 Mbps)             | 549 KB                    |
+   | T3 (44.7 Mbps)           | 546.1 KB                  |
    +--------------------------+---------------------------+
-   | OC-3 (155 Mbps)          | 1.8 MB                    |
+   | OC-3 (148.6 Mbps)        | 1.8 MB                    |
    +--------------------------+---------------------------+
-   | OC-48 (2.5 Gbps)         | 29.6 MB                   |
+   | OC-48 (2.4 Gbps)         | 28.7 MB                   |
    +--------------------------+---------------------------+
-   | OC-192 (10 Gbps)         | 118.4 MB                  |
+   | OC-192 (9.5 Gbps)        | 113.4 MB                  |
    +--------------------------+---------------------------+
-   | 10GigE (10 Gbps)         | 118.4 MB                  |
+   | 10GigE (10 Gbps)         | 119.2 MB                  |
    +--------------------------+---------------------------+
 
 In other words, TCP’s ``AdvertisedWindow`` field is in even worse
@@ -769,15 +771,15 @@ even a T3 connection across the continental United States, since a
 16-bit field allows us to advertise a window of only 64 KB.
 
 The fix is an extension to TCP that allows the receiver to advertise a
-larger window, thereby allowing the sender to fill larger delay ×
-bandwidth pipes that are made possible by high-speed networks. This
-extension involves an option that defines a *scaling factor* for the
-advertised window. That is, rather than interpreting the number that
-appears in the ``AdvertisedWindow`` field as indicating how many bytes
-the sender is allowed to have unacknowledged, this option allows the
-two sides of TCP to agree that the ``AdvertisedWindow`` field counts
-larger chunks (e.g., how many 16-byte units of data the sender can
-have unacknowledged). In other words, the window scaling option
-specifies how many bits each side should left-shift the
-``AdvertisedWindow`` field before using its contents to compute an
-effective window.
+larger window, thereby allowing the sender to fill larger
+bandwidth-delay product pipes that are made possible by high-speed
+networks. This extension involves an option that defines a *scaling
+factor* for the advertised window. That is, rather than interpreting
+the number that appears in the ``AdvertisedWindow`` field as
+indicating how many bytes the sender is allowed to have
+unacknowledged, this option allows the two sides of TCP to agree that
+the ``AdvertisedWindow`` field counts larger chunks (e.g., how many
+16-byte units of data the sender can have unacknowledged). In other
+words, the window scaling option specifies how many bits each side
+should left-shift the ``AdvertisedWindow`` field before using its
+contents to compute an effective window.


### PR DESCRIPTION
This PR aims to address issues #14 and #16 
Recalculate numbers to higher precision for Tables 1 and 2, taking account of SONET overhead
Consistently provide 1 decimal place
Use "bandwidth-delay product" consistently (rather than occasionally using delay x bandwidth product or delay-bandwidth product)